### PR TITLE
Fix docker npm install runtime order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM node:16-alpine
 WORKDIR /usr/src/app
-COPY . .
-RUN cp sample.env .env
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-RUN npm ci
 
+COPY package* ./
+COPY .npmrc ./
+COPY tsconfig* ./
+COPY babel* ./
+COPY api-server api-server
+COPY client client
+COPY curriculum curriculum
+COPY curriculum-server curriculum-server
+COPY tools tools
+COPY web web
+RUN npm ci --no-audit
+
+COPY . .
+RUN cp sample.env .env
 
 EXPOSE 3000
 CMD ["npm", "run", "seed"]


### PR DESCRIPTION
Orders matters a ton in Docker, as long as you don't change the actual code this should stop the install from running more than once

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
